### PR TITLE
Remove Chrome::Service#stop extension

### DIFF
--- a/lib/watirmark/extensions/webdriver_extensions.rb
+++ b/lib/watirmark/extensions/webdriver_extensions.rb
@@ -219,24 +219,3 @@ module Watir
   end
 
 end
-
-module Selenium
-  module WebDriver
-    module Chrome
-      class Service
-        alias :stop_original :stop
-        def stop
-          watirmark_close_browser
-          stop_original
-        end
-
-        def watirmark_close_browser
-          return if @process.nil? || @process.exited? || @stopped
-          @stopped = true
-          config = Watirmark::Configuration.instance
-          Watirmark::Session.instance.closebrowser if config.closebrowseronexit || config.headless
-        end
-      end
-    end
-  end
-end

--- a/lib/watirmark/version.rb
+++ b/lib/watirmark/version.rb
@@ -1,5 +1,5 @@
 module Watirmark
   module Version
-    STRING = '5.31.1'
+    STRING = '5.31.2'
   end
 end


### PR DESCRIPTION
Now that Chromedriver closes the browser by default, this extension no longer appears to be necessary.

It actually causes the browser to be re-opened/closed due to Watirmark::Session#initialize already closing the browser through the added exit task.

~~~~~~~~
require 'watirmark'
Watirmark::Configuration.instance.update(closebrowseronexit: true)
Watirmark::Page.browser
#=> Notice that Chrome opens, close, re-opens and closes
~~~~~~~~